### PR TITLE
Geocode sale addresses on the client for immediate map markers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import SaleCard from './components/SaleCard.jsx';
 import SaleForm from './components/SaleForm.jsx';
 import AuthPanel from './components/AuthPanel.jsx';
 import { auth, db } from './firebase';
+import { encodeGeohash } from './lib/geohash.js';
 
 function toDate(value) {
   if (!value) {
@@ -29,6 +30,72 @@ function toDate(value) {
     return value.toDate();
   }
   return new Date(value);
+}
+
+function normalizeLocation(value) {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value.lat === 'number' && typeof value.lng === 'number') {
+    return { lat: value.lat, lng: value.lng };
+  }
+
+  if (typeof value.latitude === 'number' && typeof value.longitude === 'number') {
+    return { lat: value.latitude, lng: value.longitude };
+  }
+
+  if (typeof value.toJSON === 'function') {
+    const json = value.toJSON();
+    if (json && typeof json.lat === 'number' && typeof json.lng === 'number') {
+      return { lat: json.lat, lng: json.lng };
+    }
+    if (json && typeof json.latitude === 'number' && typeof json.longitude === 'number') {
+      return { lat: json.latitude, lng: json.longitude };
+    }
+  }
+
+  return null;
+}
+
+const MAPTILER_GEOCODER_URL = 'https://api.maptiler.com/geocoding';
+
+async function geocodeAddress(address) {
+  const key = import.meta.env.VITE_MAPTILER_KEY;
+  const trimmedAddress = address?.trim();
+
+  if (!trimmedAddress) {
+    return { status: 'skipped', location: null };
+  }
+
+  if (!key) {
+    console.warn('Skipping client-side geocoding because VITE_MAPTILER_KEY is not configured.');
+    return { status: 'skipped', location: null };
+  }
+
+  const url = `${MAPTILER_GEOCODER_URL}/${encodeURIComponent(trimmedAddress)}.json?key=${key}&limit=1`;
+
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    console.error('Network error while contacting MapTiler geocoding API.', error);
+    throw new Error('Unable to reach the geocoding service. Check your connection and try again.');
+  }
+
+  if (!response.ok) {
+    console.error(`MapTiler geocoding failed: ${response.status} ${response.statusText}`);
+    throw new Error('The geocoding service responded with an error. Please try again shortly.');
+  }
+
+  const payload = await response.json();
+  const [lng, lat] = payload?.features?.[0]?.center ?? [];
+
+  if (typeof lat !== 'number' || typeof lng !== 'number') {
+    return { status: 'not_found', location: null };
+  }
+
+  return { status: 'success', location: { lat, lng } };
 }
 
 const ZIP_CODE_PATTERN = /^\d{5}(?:-?\d{4})?$/;
@@ -63,9 +130,11 @@ export default function App() {
       (snapshot) => {
         const nextSales = snapshot.docs.map((doc) => {
           const data = doc.data();
+          const loc = normalizeLocation(data.loc);
           return {
             id: doc.id,
             ...data,
+            loc,
             startsAt: toDate(data.startsAt),
             endsAt: toDate(data.endsAt),
           };
@@ -150,6 +219,17 @@ export default function App() {
       ? `${cleanedAddress}, ${locationLine}`.trim()
       : locationLine;
 
+    const geocodeResult = await geocodeAddress(fullAddress);
+
+    if (geocodeResult.status === 'not_found') {
+      throw new Error('We couldn’t find that address. Double-check the details and try again.');
+    }
+
+    const resolvedLocation = geocodeResult.status === 'success' ? geocodeResult.location : null;
+    const resolvedGeohash = resolvedLocation
+      ? encodeGeohash(resolvedLocation.lat, resolvedLocation.lng)
+      : null;
+
     const payload = {
       title: values.title.trim(),
       description: values.description?.trim() || null,
@@ -164,11 +244,20 @@ export default function App() {
       photos: [],
       ownerUid: user.uid,
       createdAt: serverTimestamp(),
-      loc: null,
-      geohash: null,
+      loc: resolvedLocation,
+      geohash: resolvedGeohash,
     };
 
+    if (resolvedLocation) {
+      payload.geocodedAt = serverTimestamp();
+    }
+
     await addDoc(collection(db, 'sales'), payload);
+
+    return {
+      geocoded: geocodeResult.status === 'success',
+      geocodeStatus: geocodeResult.status,
+    };
   };
 
   return (

--- a/src/components/SaleForm.jsx
+++ b/src/components/SaleForm.jsx
@@ -82,8 +82,12 @@ export default function SaleForm({ disabled, onCreate }) {
     setStatus({ state: 'loading', message: 'Submitting…' });
 
     try {
-      await onCreate(values);
-      setStatus({ state: 'success', message: 'Sale created! It will appear after geocoding runs.' });
+      const result = await onCreate(values);
+      let successMessage = 'Sale created! We\'ll add it to the map once the address is located.';
+      if (result?.geocoded) {
+        successMessage = 'Sale created! It should appear on the map right away.';
+      }
+      setStatus({ state: 'success', message: successMessage });
       reset(defaultValues);
     } catch (error) {
       setStatus({ state: 'error', message: error.message || 'Something went wrong.' });


### PR DESCRIPTION
## Summary
- geocode submitted sale addresses with the MapTiler API before creating Firestore documents so markers can appear right away
- compute a geohash and geocoded timestamp when coordinates are resolved
- adjust the sale form success message to reflect whether the address was geocoded immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd732039fc832aa9af0bd149d296d5