### PR TITLE
Fix map focus logic when selecting a sale

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
@@ -79,6 +79,27 @@ export default function MapView({ sales, selectedSale }) {
   const containerRef = useRef(null);
   const mapRef = useRef(null);
   const markersRef = useRef([]);
+  const selectedSaleRef = useRef(null);
+
+  const focusOnSale = useCallback((sale) => {
+    const map = mapRef.current;
+    if (!map || !sale) {
+      return;
+    }
+
+    const entry = markersRef.current.find((item) => item.id === sale.id);
+    if (!entry || !entry.position) {
+      return;
+    }
+
+    map.flyTo({
+      center: [entry.position.lng, entry.position.lat],
+      zoom: Math.max(map.getZoom(), 14),
+      essential: true,
+    });
+
+    entry.popup?.setLngLat([entry.position.lng, entry.position.lat]).addTo(map);
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current || mapRef.current) {
@@ -114,40 +135,26 @@ export default function MapView({ sales, selectedSale }) {
       .map((sale) => ({ sale, position: toDisplayLocation(sale) }))
       .filter((entry) => entry.position)
       .forEach(({ sale, position }) => {
-        const popup = new maplibregl.Popup({ closeButton: false }).setHTML(popupHtml(sale));
+        const popup = new maplibregl.Popup({ closeButton: false })
+          .setLngLat([position.lng, position.lat])
+          .setHTML(popupHtml(sale));
         const marker = new maplibregl.Marker({ color: STATUS_COLORS[sale.status] ?? '#ef4444' })
           .setLngLat([position.lng, position.lat])
           .setPopup(popup)
           .addTo(map);
 
-        markersRef.current.push({ id: sale.id, marker, popup });
+        markersRef.current.push({ id: sale.id, marker, popup, position });
       });
-  }, [sales]);
+
+    if (selectedSaleRef.current) {
+      focusOnSale(selectedSaleRef.current);
+    }
+  }, [sales, focusOnSale]);
 
   useEffect(() => {
-    const map = mapRef.current;
-    if (!map || !selectedSale) {
-      return;
-    }
-
-    const entry = markersRef.current.find((item) => item.id === selectedSale.id);
-    if (!entry) {
-      return;
-    }
-
-    const position = toDisplayLocation(selectedSale);
-    if (!position) {
-      return;
-    }
-
-    map.flyTo({
-      center: [position.lng, position.lat],
-      zoom: Math.max(map.getZoom(), 14),
-      essential: true,
-    });
-
-    entry.popup?.addTo(map);
-  }, [selectedSale]);
+    selectedSaleRef.current = selectedSale ?? null;
+    focusOnSale(selectedSale ?? null);
+  }, [selectedSale, focusOnSale]);
 
   return <div ref={containerRef} style={styles.mapContainer} />;
 }


### PR DESCRIPTION
## Summary
- keep track of marker positions and anchor popups at creation time
- centralize the logic that flies to and opens the selected sale marker
- ensure the popup opens once markers render, even if the selection happened earlier

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cebef46b44832ab4e1a1f0084e4638